### PR TITLE
Don't explode when a rel attribute exists without a base tag.

### DIFF
--- a/lib/microformats2/collection.rb
+++ b/lib/microformats2/collection.rb
@@ -110,7 +110,7 @@ module Microformats2
     end
     
     def absolutize(href)
-      if URI.parse(href).absolute?
+      if URI.parse(href).absolute? || @base.nil?
         href
       else
         URI.join(@base, href).to_s

--- a/spec/lib/microformats2/collection_spec.rb
+++ b/spec/lib/microformats2/collection_spec.rb
@@ -190,6 +190,17 @@ describe Microformats2::Collection do
         end
       end
     end
+
+    describe "rels-that-drop-the-base.html" do
+      before do
+        html = "spec/support/lib/microformats2/rels-that-drop-the-base.html"
+        @collection = Microformats2.parse(html)
+      end
+
+      it "keeps the relative path" do
+        @collection.to_hash[:rels]["stylesheet"].should eq([ "/path/to/stylesheet.css" ])
+      end
+    end
   end
 
 

--- a/spec/support/lib/microformats2/rels-that-drop-the-base.html
+++ b/spec/support/lib/microformats2/rels-that-drop-the-base.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Rels without Base Test</title>
+<link href="/path/to/stylesheet.css" media="all" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<li><a rel="met friend" href="http://adactio.com/">Jeremy Keith</a></li>
+<li><a rel="met friend" href="http://tantek.com/">Tantek Çelik</a></li>
+</body>
+</html>


### PR DESCRIPTION
It tries to build an absolute URL for link tags that contain a rel
attribute and a relative URL, using the <base> tag to decide what to
prefix the relative URLs with.  It's very common for people to omit the
base tag and to use rel attributes in stylesheets, and that blows up the
parser.

Now we don't attempt to build absolute URLs when the base URL can't be
determined.
