### PR TITLE
Convert a spec to an explicit subject and lets.

### DIFF
--- a/spec/lib/microformats2/absolute_uri_spec.rb
+++ b/spec/lib/microformats2/absolute_uri_spec.rb
@@ -2,72 +2,47 @@ require "spec_helper"
 require "microformats2/absolute_uri"
 
 describe Microformats2::AbsoluteUri do
-  let(:subject) { Microformats2::AbsoluteUri }
-
   describe "#absolutize" do
+    subject { Microformats2::AbsoluteUri.new(base, relative).absolutize }
+    let(:base) { nil }
+
     context "when relative is nil" do
-      it "returns nil" do
-        base = nil
-        relative = nil
-        expect(subject.new(base, relative).absolutize).to be_nil
-      end
+      let(:relative) { nil }
+      it { should be_nil }
     end
 
     context "when relative is an empty string" do
-      it "returns nil" do
-        base = nil
-        relative = ""
-        expect(subject.new(base, relative).absolutize).to be_nil
+      let(:relative) { "" }
+      it { should be_nil }
+    end
+
+    context "when relative is a valid absolute URI" do
+      let(:relative) { "http://google.com" }
+      it { should eq("http://google.com/") }
+    end
+
+    context "when relative is a valid non-absolute URI" do
+      let(:relative) { "bar/qux" }
+
+      context "and base is present but not absolute" do
+        let(:base) { "foo" }
+        it { should eq("bar/qux") }
+      end
+
+      context "and base is present and absolute" do
+        let(:base) { "http://google.com" }
+        it { should eq("http://google.com/bar/qux") }
+      end
+
+      context "and base is not present" do
+        let(:base) { nil }
+        it { should eq("bar/qux") }
       end
     end
 
-    context "when relative is a valid URI" do
-      context "and relative is absolute" do
-        it "returns normalized relative" do
-          base = nil
-          relative = "http://google.com"
-          result = "http://google.com/"
-          expect(subject.new(base, relative).absolutize).to eq result
-        end
-      end
-
-      context "and relative is not absolute" do
-        context "and base is present but not absolute" do
-          it "returns normalized relative" do
-            base = "foo"
-            relative = "bar/qux"
-            result = "bar/qux"
-            expect(subject.new(base, relative).absolutize).to eq result
-           end
-        end
-
-        context "and base is present and absolute" do
-          it "returns normalized base and relative joined" do
-            base = "http://google.com"
-            relative = "foo/bar"
-            result = "http://google.com/foo/bar"
-            expect(subject.new(base, relative).absolutize).to eq result
-          end
-        end
-
-        context "and base is not present" do
-          it "returns normalized relative" do
-            base = nil
-            relative = "foo/bar"
-            result = "foo/bar"
-            expect(subject.new(base, relative).absolutize).to eq result
-          end
-        end
-      end
-    end
-
-    context "when relative in an invliad URI" do
-      it "returns relative" do
-        base = nil
-        relative = "git@github.com:G5/microformats2.git"
-        result = "git@github.com:G5/microformats2.git"
-        expect(subject.new(base, relative).absolutize).to eq result
-      end
+    context "when relative is an invalid URI" do
+      let(:relative) { "git@github.com:G5/microformats2.git" }
+      it { should eq("git@github.com:G5/microformats2.git") }
     end
   end
 end


### PR DESCRIPTION
@jlsuttles I was reading your spec and thinking it would read easier with a subject and some let variables. I don't know if you've used these before and don't like them. I will not feel bad if you don't want to use this. On one hand, I can read each one of your tests and not have to look anywhere else to know what's going on, on the other hand I have to skim through more text to know what's happening.
