### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---color
 --format documentation
 --order random
 --require spec_helper

--- a/.rubocop
+++ b/.rubocop
@@ -1,4 +1,3 @@
---display-cop-names
 --display-style-guide
 --extra-details
 --parallel

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 require:
   - rubocop-rspec
 
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+
 Metrics/LineLength:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,5 @@
-AllCops:
-  Exclude:
-    - "spec/**/*"
+require:
+  - rubocop-rspec
 
 Metrics/LineLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,15 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Enabled: false
 
+RSpec/ExampleLength:
+  Max: 15
+
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/NestedGroups:
+  Max: 6
+
 Style/Documentation:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
 
 Metrics/BlockLength:
   Exclude:
+    - microformats.gemspec
     - spec/**/*.rb
 
 Metrics/LineLength:

--- a/bin/microformats
+++ b/bin/microformats
@@ -4,25 +4,26 @@ require 'microformats'
 require 'json'
 
 def print_usage
-  puts "Usage: microformats (URL, filepath, or HTML)"
+  puts 'Usage: microformats (URL, filepath, or HTML)'
 end
 
 def process_html(html)
-    collection = Microformats.parse(html)
-    puts JSON.pretty_generate(JSON[collection.to_json.to_s])
+  collection = Microformats.parse(html)
+  puts JSON.pretty_generate(JSON[collection.to_json.to_s])
 end
 
 if STDIN.tty?
-  unless ARGV[0].nil?
-    process_html(ARGV[0])
-  else
+  if ARGV[0].nil?
     print_usage
+  else
+    process_html(ARGV[0])
   end
 else
   html = STDIN.read
-  unless html.nil?
-    process_html(html)
-  else
+
+  if html.nil?
     print_usage
+  else
+    process_html(html)
   end
 end

--- a/lib/microformats.rb
+++ b/lib/microformats.rb
@@ -22,7 +22,7 @@ module Microformats
     def read_html(html)
       Parser.new.read_html(html)
     end
-  end # class << self
+  end
 
   class InvalidPropertyPrefix < StandardError; end
 end

--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.1'
   spec.add_development_dependency 'rb-fsevent', '~> 0.10.3'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.57.2'
+  spec.add_development_dependency 'rubocop', '~> 0.58.1'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.27'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'simplecov-console', '~> 0.4.2'

--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rb-fsevent', '~> 0.10.3'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rubocop', '~> 0.57.2'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.27'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'simplecov-console', '~> 0.4.2'
   spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'

--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'microformats/version'

--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
 
   spec.add_runtime_dependency 'json', '~> 2.1'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.1'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.3'
 end

--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -23,15 +23,15 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = 'Prior to version 4.0.0, the microformats gem was named "microformats2."'
 
-  spec.add_development_dependency 'bundler', '~> 1.15', '>= 1.15.1'
+  spec.add_development_dependency 'bundler', '~> 1.16', '>= 1.16.2'
   spec.add_development_dependency 'guard-rspec', '~> 4.7', '>= 4.7.3'
-  spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'rb-fsevent', '~> 0.10.2'
+  spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.1'
+  spec.add_development_dependency 'rb-fsevent', '~> 0.10.3'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.52.1'
-  spec.add_development_dependency 'simplecov', '~> 0.15.1'
+  spec.add_development_dependency 'rubocop', '~> 0.57.2'
+  spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'simplecov-console', '~> 0.4.2'
-  spec.add_development_dependency 'webmock', '~> 3.3'
+  spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
 
   spec.add_runtime_dependency 'json', '~> 2.1'
   spec.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.1'

--- a/spec/lib/microformats/absolute_uri_spec.rb
+++ b/spec/lib/microformats/absolute_uri_spec.rb
@@ -1,53 +1,61 @@
 describe Microformats::AbsoluteUri do
-  describe "#absolutize" do
-    subject { Microformats::AbsoluteUri.new(relative, base: base).absolutize }
+  describe '#absolutize' do
+    subject { described_class.new(relative, base: base).absolutize }
 
-    context "when relative is nil" do
+    context 'when relative is nil' do
       let(:relative) { nil }
-      let(:base) { "http://example.com" }
-      it { should eq base }
+      let(:base) { 'http://example.com' }
+
+      it { is_expected.to eq(base) }
     end
 
-    context "when relative is an empty string" do
-      let(:relative) { "" }
-      let(:base) { "http://example.com" }
-      it { should eq base }
+    context 'when relative is an empty string' do
+      let(:relative) { '' }
+      let(:base) { 'http://example.com' }
+
+      it { is_expected.to eq(base) }
     end
 
-    context "when relative is a valid absolute URI" do
+    context 'when relative is a valid absolute URI' do
       let(:base) { nil }
-      let(:relative) { "http://google.com" }
-      it { should eq("http://google.com") }
+      let(:relative) { 'http://google.com' }
+
+      it { is_expected.to eq('http://google.com') }
     end
 
-    context "when relative is a valid non-absolute URI" do
-      let(:relative) { "bar/qux" }
+    context 'when relative is a valid non-absolute URI' do
+      let(:relative) { 'bar/qux' }
 
-      context "and base is present but not absolute" do
-        let(:base) { "foo" }
-        it { should eq("bar/qux") }
+      context 'when base is present but not absolute' do
+        let(:base) { 'foo' }
+
+        it { is_expected.to eq('bar/qux') }
       end
 
-      context "and base is present and absolute" do
-        let(:base) { "http://google.com" }
-        it { should eq("http://google.com/bar/qux") }
+      context 'when base is present and absolute' do
+        let(:base) { 'http://google.com' }
+
+        it { is_expected.to eq('http://google.com/bar/qux') }
       end
 
-      context "and base is not present" do
+      context 'when base is not present' do
         let(:base) { nil }
-        it { should eq("bar/qux") }
+
+        it { is_expected.to eq('bar/qux') }
       end
 
-      context "and base has a subdir" do
-        let(:base) { "http://google.com/asdf.html" }
-        it { should eq("http://google.com/bar/qux") }
+      context 'when base has a subdir' do
+        let(:base) { 'http://google.com/asdf.html' }
+
+        it { is_expected.to eq('http://google.com/bar/qux') }
       end
     end
 
-    context "when relative is an invalid URI" do
+    context 'when relative is an invalid URI' do
       let(:base) { nil }
-      let(:relative) { "git@github.com:indieweb/microformats-ruby.git" }
-      it { should eq("git@github.com:indieweb/microformats-ruby.git") }
+      let(:relative) { 'git@github.com:indieweb/microformats-ruby.git' }
+
+      it { is_expected.to eq('git@github.com:indieweb/microformats-ruby.git') }
     end
   end
 end

--- a/spec/lib/microformats/collection_spec.rb
+++ b/spec/lib/microformats/collection_spec.rb
@@ -1,57 +1,51 @@
 describe Microformats::Collection do
   let(:parser) { Microformats::Parser.new }
 
+  describe 'collection to hash or string' do
+    let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>' }
 
-    describe "collection to hash or string" do
-      before do
-        @html = '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>'
-        @html.freeze
-      end
-
-      it "is accessible as a hash []" do
-          expect(Microformats.parse(@html)['items'][0]['properties']['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "can convert to hash" do
-          expect(Microformats.parse(@html).to_hash['items'][0]['properties']['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "can convert to hash by to_h" do
-          expect(Microformats.parse(@html).to_h['items'][0]['properties']['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "converts to string" do
-          expect(Microformats.parse(@html).to_s).to eq("{\"items\"=>[{\"type\"=>[\"h-card\"], \"properties\"=>{\"name\"=>[\"Jessica Lynn Suttles\"]}}], \"rels\"=>{}, \"rel-urls\"=>{}}")
-      end
+    it 'is accessible as a hash []' do
+      expect(Microformats.parse(html)['items'][0]['properties']['name'][0]).to eq('Jessica Lynn Suttles')
     end
 
-    describe "collection functions" do
-      before do
-        @html = '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p><a rel="canonical" class="u-url" href="https://example.com/">homepage</a></div><div class="h-as-sample"><p class="p-name">sample</p></div>'
-        @html.freeze
-      end
-
-      it "is has rels function" do
-          expect(Microformats.parse(@html).rels['canonical'][0]).to eq('https://example.com/')
-      end
-
-      it "is has rel_urls function" do
-          expect(Microformats.parse(@html).rel_urls['https://example.com/']['rels'][0]).to eq('canonical')
-      end
-
-      it "has respond_to? function" do
-          expect(Microformats.parse(@html)).to respond_to(:respond_to?)
-      end
-
-      it "supports old parser function calls by h- name" do
-          expect(Microformats.parse(@html).card.to_hash).to eq(Microformats.parse(@html).items[0].to_hash)
-          expect(Microformats.parse(@html).card(:all)[0].to_hash).to eq(Microformats.parse(@html).items[0].to_hash)
-          expect(Microformats.parse(@html).card(0).to_hash).to eq(Microformats.parse(@html).items[0].to_hash)
-          expect(Microformats.parse(@html).card(3).to_hash).to eq(Microformats.parse(@html).items[0].to_hash)
-          expect(Microformats.parse(@html).as_sample.to_hash).to eq(Microformats.parse(@html).items[1].to_hash)
-      end
-
-      it "has an items function that returns an array of ParserResult objects" do
-          expect(Microformats.parse(@html).items[0]).to be_kind_of Microformats::ParserResult
-      end
-
+    it 'can convert to hash' do
+      expect(Microformats.parse(html).to_hash['items'][0]['properties']['name'][0]).to eq('Jessica Lynn Suttles')
     end
 
+    it 'can convert to hash by to_h' do
+      expect(Microformats.parse(html).to_h['items'][0]['properties']['name'][0]).to eq('Jessica Lynn Suttles')
+    end
+
+    it 'converts to string' do
+      expect(Microformats.parse(html).to_s).to eq('{"items"=>[{"type"=>["h-card"], "properties"=>{"name"=>["Jessica Lynn Suttles"]}}], "rels"=>{}, "rel-urls"=>{}}')
+    end
+  end
+
+  describe 'collection functions' do
+    let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p><a rel="canonical" class="u-url" href="https://example.com/">homepage</a></div><div class="h-as-sample"><p class="p-name">sample</p></div>' }
+
+    it 'is has rels function' do
+      expect(Microformats.parse(html).rels['canonical'][0]).to eq('https://example.com/')
+    end
+
+    it 'is has rel_urls function' do
+      expect(Microformats.parse(html).rel_urls['https://example.com/']['rels'][0]).to eq('canonical')
+    end
+
+    it 'has respond_to? function' do
+      expect(Microformats.parse(html)).to respond_to(:respond_to?)
+    end
+
+    it 'supports old parser function calls by h- name' do
+      expect(Microformats.parse(html).card.to_hash).to eq(Microformats.parse(html).items[0].to_hash)
+      expect(Microformats.parse(html).card(:all)[0].to_hash).to eq(Microformats.parse(html).items[0].to_hash)
+      expect(Microformats.parse(html).card(0).to_hash).to eq(Microformats.parse(html).items[0].to_hash)
+      expect(Microformats.parse(html).card(3).to_hash).to eq(Microformats.parse(html).items[0].to_hash)
+      expect(Microformats.parse(html).as_sample.to_hash).to eq(Microformats.parse(html).items[1].to_hash)
+    end
+
+    it 'has an items function that returns an array of ParserResult objects' do
+      expect(Microformats.parse(html).items[0]).to be_kind_of(Microformats::ParserResult)
+    end
+  end
 end

--- a/spec/lib/microformats/parser_result_spec.rb
+++ b/spec/lib/microformats/parser_result_spec.rb
@@ -1,51 +1,47 @@
 describe Microformats::ParserResult do
   let(:parser) { Microformats::Parser.new }
 
-    describe "conversion functions" do
-      before do
-        @html = '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>'
-        @html.freeze
-        @item = Microformats.parse(@html).items[0]
-      end
+  describe 'conversion functions' do
+    let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>' }
+    let(:item) { Microformats.parse(html).items[0] }
 
-      it "is accessible as a hash []" do
-          expect(@item['properties']['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "can convert to hash" do
-          expect(@item.to_hash['properties']['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "can convert to hash by to_h" do
-          expect(@item.to_h['properties']['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "converts to json" do
-          expect(@item.to_json).to eq("{\"type\":[\"h-card\"],\"properties\":{\"name\":[\"Jessica Lynn Suttles\"]}}")
-      end
-      it "converts to string" do
-          expect(@item.to_s).to eq(@item.to_h.to_s)
-      end
+    it 'is accessible as a hash []' do
+      expect(item['properties']['name'][0]).to eq('Jessica Lynn Suttles')
     end
 
-    describe "parser result functions" do
-      before do
-        @html = '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p><a rel="canonical" class="u-url u-like-of" href="https://example.com/">homepage</a></div>'
-        @html.freeze
-        @item = Microformats.parse(@html).items[0]
-      end
-
-      it "has respond_to? function" do
-          expect(@item).to respond_to(:respond_to?)
-      end
-
-      it "returns PropertySets" do
-          expect(@item.properties).to be_kind_of Microformats::PropertySet
-      end
-
-      it "supports old parser function calls by property name" do
-          expect(@item.name).to eq("Jessica Lynn Suttles")
-          expect(@item.url).to eq("https://example.com/")
-          expect(@item.like_of).to eq("https://example.com/")
-      end
+    it 'can convert to hash' do
+      expect(item.to_hash['properties']['name'][0]).to eq('Jessica Lynn Suttles')
     end
 
+    it 'can convert to hash by to_h' do
+      expect(item.to_h['properties']['name'][0]).to eq('Jessica Lynn Suttles')
+    end
 
+    it 'converts to json' do
+      expect(item.to_json).to eq('{"type":["h-card"],"properties":{"name":["Jessica Lynn Suttles"]}}')
+    end
+
+    it 'converts to string' do
+      expect(item.to_s).to eq(item.to_h.to_s)
+    end
+  end
+
+  describe 'parser result functions' do
+    let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p><a rel="canonical" class="u-url u-like-of" href="https://example.com/">homepage</a></div>' }
+    let(:item) { Microformats.parse(html).items[0] }
+
+    it 'has respond_to? function' do
+      expect(item).to respond_to(:respond_to?)
+    end
+
+    it 'returns PropertySets' do
+      expect(item.properties).to be_kind_of Microformats::PropertySet
+    end
+
+    it 'supports old parser function calls by property name' do
+      expect(item.name).to eq('Jessica Lynn Suttles')
+      expect(item.url).to eq('https://example.com/')
+      expect(item.like_of).to eq('https://example.com/')
+    end
+  end
 end

--- a/spec/lib/microformats/parser_spec.rb
+++ b/spec/lib/microformats/parser_spec.rb
@@ -1,122 +1,123 @@
 describe Microformats::Parser do
-  let(:parser) { Microformats::Parser.new }
+  let(:parser) { described_class.new }
 
-  describe "#http_headers" do
-    it "starts as a blank hash" do
+  describe '#http_headers' do
+    it 'starts as a blank hash' do
       expect(parser.http_headers).to eq({})
     end
 
-    describe "open file" do
+    describe 'open file' do
       before do
-        parser.parse("spec/support/lib/microformats/simple.html")
+        parser.parse('spec/support/lib/microformats/simple.html')
       end
 
-      it "doesn't save #http_headers" do
+      it 'does not save #http_headers' do
         expect(parser.http_headers).to eq({})
       end
-      it "saves #http_body" do
-        expect(parser.http_body).to include "<!DOCTYPE html>"
+
+      it 'saves #http_body' do
+        expect(parser.http_body).to include('<!DOCTYPE html>')
       end
     end
 
-    describe "http response" do
+    describe 'http response' do
       before do
-        stub_request(:get, "http://www.example.com/").
-           with(:headers => {"Accept"=>"*/*", "User-Agent"=>"Ruby"}).
-           to_return(:status => 200, :body => "abc", :headers => {"Content-Length" => 3})
-        parser.parse("http://www.example.com")
+        stub_request(:get, 'http://www.example.com/')
+          .with(headers: { 'Accept': '*/*', 'User-Agent': 'Ruby' })
+          .to_return(status: 200, body: 'abc', headers: { 'Content-Length': 3 })
+
+        parser.parse('http://www.example.com')
       end
 
-      it "saves #http_headers" do
-        expect(parser.http_headers).to eq({"content-length" => "3"})
-      end
-      it "saves #http_body" do
-        expect(parser.http_body).to eq("abc")
-      end
-    end
-  end
-
-  describe "#bad_input" do
-
-    describe "space after url" do
-      before do
-        stub_request(:get, "http://www.example.com/").
-           with(:headers => {"Accept"=>"*/*", "User-Agent"=>"Ruby"}).
-           to_return(:status => 200, :body => "abc", :headers => {"Content-Length" => 3})
-        parser.parse("http://www.example.com ")
+      it 'saves #http_headers' do
+        expect(parser.http_headers).to eq('content-length' => '3')
       end
 
-      it "saves #http_body" do
-        expect(parser.http_body).to eq("abc")
+      it 'saves #http_body' do
+        expect(parser.http_body).to eq('abc')
       end
     end
   end
 
-  describe "#frozen_strings" do
-
-    describe "frozen url" do
+  describe '#bad_input' do
+    describe 'space after url' do
       before do
-        stub_request(:get, "http://www.example.com/").
-           with(:headers => {"Accept"=>"*/*", "User-Agent"=>"Ruby"}).
-           to_return(:status => 200, :body => "abc", :headers => {"Content-Length" => 3})
-        url = "http://www.example.com"
+        stub_request(:get, 'http://www.example.com/')
+          .with(headers: { 'Accept': '*/*', 'User-Agent': 'Ruby' })
+          .to_return(status: 200, body: 'abc', headers: { 'Content-Length': 3 })
+        parser.parse('http://www.example.com ')
+      end
+
+      it 'saves #http_body' do
+        expect(parser.http_body).to eq('abc')
+      end
+    end
+  end
+
+  describe '#frozen_strings' do
+    describe 'frozen url' do
+      before do
+        stub_request(:get, 'http://www.example.com/')
+          .with(headers: { 'Accept': '*/*', 'User-Agent': 'Ruby' })
+          .to_return(status: 200, body: 'abc', headers: { 'Content-Length': 3 })
+
+        url = 'http://www.example.com'
         url.freeze
         parser.parse(url)
       end
 
-      it "saves #http_body" do
-        expect(parser.http_body).to eq("abc")
+      it 'saves #http_body' do
+        expect(parser.http_body).to eq('abc')
       end
     end
 
-    describe "frozen html" do
-      before do
-        @html = '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>'
-        @html.freeze
-      end
+    describe 'frozen html' do
+      let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>' }
 
-      it "returns Collection" do
-        expect(Microformats.parse(@html)).to be_kind_of Microformats::Collection
+      it 'returns Collection' do
+        expect(Microformats.parse(html)).to be_kind_of Microformats::Collection
       end
     end
   end
 
-  describe "edge cases" do
-    cases_dir = "spec/support/lib/edge_cases/"
-    Dir[File.join(cases_dir, "*")].keep_if { |f| f =~ /([.]js$)/ }.each do |json_file|
-      it "#{json_file.split("/").last}" do
+  describe 'edge cases' do
+    cases_dir = 'spec/support/lib/edge_cases/'
 
-        html_file = json_file.gsub(/([.]js$)/, ".html")
-        html = open(html_file).read
-        json = open(json_file).read
+    Dir[File.join(cases_dir, '*')].keep_if { |f| f =~ /([.]js$)/ }.each do |json_file|
+      it json_file.split('/').last.to_s do
+        html_file = json_file.gsub(/([.]js$)/, '.html')
+        html = File.read(html_file)
+        json = File.read(json_file)
 
         expect(JSON.parse(Microformats.parse(html).to_json)).to eq(JSON.parse(json))
       end
     end
   end
 
-  describe "microformat-tests/tests" do
-    cases_dir = "vendor/tests/tests/*"
-    #cases_dir = "vendor/tests/tests/microformats-mixed"
-    #cases_dir = "vendor/tests/tests/microformats-v1"
-    #cases_dir = "vendor/tests/tests/microformats-working"
-    #cases_dir = "vendor/tests/tests/microformats-v2" #limit to only v2 for now
-    Dir[File.join(cases_dir, "*")].each do |page_dir|
-    describe page_dir.split("/")[-2..-1].join("/") do
-        Dir[File.join(page_dir, "*")].keep_if { |f| f =~ /([.]json$)/ }.each do |json_file|
-          it "#{json_file.split("/").last}" do
+  describe 'microformat-tests/tests' do
+    cases_dir = 'vendor/tests/tests/*'
+    # cases_dir = 'vendor/tests/tests/microformats-mixed'
+    # cases_dir = 'vendor/tests/tests/microformats-v1'
+    # cases_dir = 'vendor/tests/tests/microformats-working'
+    # cases_dir = 'vendor/tests/tests/microformats-v2' #limit to only v2 for now
 
-            if  json_file =~ /\/includes\//
-              pending "include-pattern are not yet implemented"
-            elsif json_file =~ /\/h-entry\/urlincontent/
-              pending "known issue / this is an aspect of nokogiri / won't fix"
-            elsif json_file =~ /\/hcard\/email/
-              pending "believed issue with the test suite, test needs to be fixed"
+    Dir[File.join(cases_dir, '*')].each do |page_dir|
+      describe page_dir.split('/')[-2..-1].join('/') do
+        Dir[File.join(page_dir, '*')].keep_if { |f| f =~ /([.]json$)/ }.each do |json_file|
+          it json_file.split('/').last.to_s do
+            if json_file.match?(%r{/includes/})
+              pending 'include-pattern are not yet implemented'
+            elsif json_file.match?(%r{/h-entry/urlincontent})
+              pending 'known issue / this is an aspect of nokogiri / won\'t fix'
+            elsif json_file.match?(%r{/hcard/email})
+              pending 'believed issue with the test suite, test needs to be fixed'
             end
-            #pending "These are dynamic tests that are not yet passing so commenting out for now"
-            html_file = json_file.gsub(/([.]json$)/, ".html")
-            html = open(html_file).read
-            json = open(json_file).read
+
+            # pending 'These are dynamic tests that are not yet passing so commenting out for now'
+
+            html_file = json_file.gsub(/([.]json$)/, '.html')
+            html = File.read(html_file)
+            json = File.read(json_file)
 
             expect(JSON.parse(Microformats.parse(html, base: 'http://example.com').to_json)).to eq(JSON.parse(json))
           end
@@ -124,5 +125,4 @@ describe Microformats::Parser do
       end
     end
   end
-
 end

--- a/spec/lib/microformats/property_set_spec.rb
+++ b/spec/lib/microformats/property_set_spec.rb
@@ -1,28 +1,28 @@
 describe Microformats::PropertySet do
-  let(:parser) { Microformats::Parser.new }
+  let(:parser) { described_class.new }
 
-    describe "conversion functions" do
-      before do
-        @html = '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>'
-        @html.freeze
-        @set = Microformats.parse(@html).items[0].properties
-      end
+  describe 'conversion functions' do
+    let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>' }
+    let(:set) { Microformats.parse(html).items[0].properties }
 
-      it "is accessible as a hash []" do
-          expect(@set['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "can convert to hash" do
-          expect(@set.to_hash['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "can convert to hash by to_h" do
-          expect(@set.to_h['name'][0]).to eq("Jessica Lynn Suttles")
-      end
-      it "converts to json" do
-          expect(@set.to_json).to eq("{\"name\":[\"Jessica Lynn Suttles\"]}")
-      end
-      it "converts to string" do
-          expect(@set.to_s).to eq(@set.to_h.to_s)
-      end
+    it 'is accessible as a hash []' do
+      expect(set['name'][0]).to eq('Jessica Lynn Suttles')
     end
 
+    it 'can convert to hash' do
+      expect(set.to_hash['name'][0]).to eq('Jessica Lynn Suttles')
+    end
+
+    it 'can convert to hash by to_h' do
+      expect(set.to_h['name'][0]).to eq('Jessica Lynn Suttles')
+    end
+
+    it 'converts to json' do
+      expect(set.to_json).to eq('{"name":["Jessica Lynn Suttles"]}')
+    end
+
+    it 'converts to string' do
+      expect(set.to_s).to eq(set.to_h.to_s)
+    end
+  end
 end

--- a/spec/lib/microformats_spec.rb
+++ b/spec/lib/microformats_spec.rb
@@ -1,30 +1,31 @@
 describe Microformats do
-  before do
-    @html = <<-HTML.strip
-      <div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>
-    HTML
-  end
+  let(:html) { '<div class="h-card"><p class="p-name">Jessica Lynn Suttles</p></div>' }
 
-  describe "::parse" do
-    it "returns Collection" do
-      expect(Microformats.parse(@html)).to be_kind_of Microformats::Collection
+  describe '::parse' do
+    it 'returns Collection' do
+      expect(described_class.parse(html)).to be_kind_of(Microformats::Collection)
     end
   end
 
-  describe "::read_html" do
-    it "can be a string of html" do
-      expect(Microformats.read_html(@html)).to include @html
+  describe '::read_html' do
+    it 'can be a string of html' do
+      expect(described_class.read_html(html)).to include(html)
     end
-    it "can be a file path to html" do
-      html = "spec/support/lib/microformats/simple.html"
-      expect(Microformats.read_html(html)).to include "<div class=\"h-card\">"
+
+    it 'can be a file path to html' do
+      html = 'spec/support/lib/microformats/simple.html'
+
+      expect(described_class.read_html(html)).to include('<div class="h-card">')
     end
-    it "can be a url to html" do
-      stub_request(:get, "http://google.com/").
-               with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
-               to_return(:status => 200, :body => "google", :headers => {})
-      html = "http://google.com"
-      expect(Microformats.read_html(html)).to include "google"
+
+    it 'can be a url to html' do
+      stub_request(:get, 'http://google.com/')
+        .with(headers: { 'Accept': '*/*', 'User-Agent': 'Ruby' })
+        .to_return(status: 200, body: 'google', headers: {})
+
+      html = 'http://google.com'
+
+      expect(described_class.read_html(html)).to include('google')
     end
   end
 end


### PR DESCRIPTION
This PR continues cleanup work on the gem's code and specs using recommendations from RuboCop as a guide. It also adds [the rubocop-rspec gem](https://rubygems.org/gems/rubocop-rspec) for linting spec files.

Additional comments posted inline.