### PR TITLE
CI: Update matrix to 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 rvm:
   - 2.4.5
   - 2.5.3
-  - 2.6.0
+  - 2.6.1
 before_install:
   - gem update --system
   - gem update bundler


### PR DESCRIPTION
This PR bumps the version of the MRI 2.6 to 2.6.1