### PR TITLE
Remove upper limit on Ruby versions

### DIFF
--- a/microformats.gemspec
+++ b/microformats.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'microformats/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = ['>= 2.4', '< 3.2']
+  spec.required_ruby_version = ['>= 2.4']
 
   spec.name          = 'microformats'
   spec.version       = Microformats::VERSION


### PR DESCRIPTION
This way we can test against pre-released versions of Ruby.

Just to explain my use case: I'm testing the edge version of Ruby with various things including Mastodon, but the upper limit specified in this gemspec means I can't install the gem with Ruby 3.2.

I ran the tests on 3.2, and they were failing.  So I ran the test with Ruby 3.1 and they were failing in the same way.  I don't think there's anything in Ruby 3.2 that would have broken this library, and since the failures are the same, I think it's OK to remove this limit.

Thank you!